### PR TITLE
ci: update GitHub Actions for Node.js 24

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: '1.23' # Specify your Go version here
 
@@ -59,7 +59,7 @@ jobs:
         fi
 
     - name: Post coverage comparison in PR
-      uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+      uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
       with:
         header: Coverage Report
         path: coverage-report.txt

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up Go
-      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: 1.23  # Specify a compatible Go version, like 1.20
 


### PR DESCRIPTION
## What changed

- Upgrade `actions/checkout` to `v7.0.1`.
- Upgrade `actions/setup-go` to `v7.0.0`.
- Upgrade `marocchino/sticky-pull-request-comment` to `v3.0.5`.

## Files changed

- `.github/workflows/coverage.yml`
- `.github/workflows/go.yml`

## Why

This work addresses [isovalent/roadmap#3310](https://github.com/isovalent/roadmap/issues/3310).

GitHub Actions runners are moving to Node.js 24 and dropping older JavaScript runtimes. Updating these actions keeps the affected workflows operational after that transition.

External actions remain pinned to immutable commit SHAs so a mutable tag cannot change the workflow implementation without review.
